### PR TITLE
make root function and enum prefixes valid c identifiers

### DIFF
--- a/source/compiler/builds.axe
+++ b/source/compiler/builds.axe
@@ -99,7 +99,7 @@ def prefix_root_enums(node: ref ASTNode, mprefix: string) {
     if equals_c(nt, "Enum") {
         val ename: string = node.data.enum_node.name;
         if str_len(mprefix) > 0 and !has_double_underscore(ename) {
-            mut new_name: string = mprefix;
+            mut new_name: string = to_c_identifier(mprefix);
             new_name = concat_c(new_name, "__");
             new_name = concat(new_name, ename);
             node.data.enum_node.name = new_name;
@@ -131,7 +131,7 @@ def prefix_root_functions(node: ref ASTNode, mprefix: string) {
         val fname: string = node.data.function.name;
         if !equals_c(fname, "main") {
              if str_len(mprefix) > 0 and !has_double_underscore(fname) {
-                mut new_name: string = mprefix;
+                mut new_name: string = to_c_identifier(mprefix);
                 new_name = concat(new_name, str("__"));
                 new_name = concat(new_name, fname);
                 
@@ -152,6 +152,35 @@ def prefix_root_functions(node: ref ASTNode, mprefix: string) {
             ci = ci + 1;
         }
     }
+}
+
+/// If identifier starts with a digit, prepend an underscore
+/// Replace special characters with '_'
+def to_c_identifier(identifier: string): string {
+    val len: i32 = str_len(identifier);
+    mut sb: StringBuilder = StringBuilder.init(len + 1);
+    
+    if is_digit(cast[i32](get_char(identifier, 0))) {
+        StringBuilder.append_char(addr(sb), '_');
+    }
+
+    mut i: i32 = 0;
+    loop {
+        if i >= len {
+            break;
+        }
+        val c: char = get_char(identifier, i);
+        if is_alphanum(cast[i32](c)) {
+            StringBuilder.append_char(addr(sb), c);
+        } else {
+            StringBuilder.append_char(addr(sb), '_');
+        }
+        i++;
+    }
+
+    val result: string = StringBuilder.to_string(addr(sb));
+    StringBuilder.destroy(addr(sb));
+    return result;
 }
 
 /// Print AST node with indentation for debugging
@@ -956,4 +985,7 @@ test {
     model_ast.children = nil;
 
     collect_model_names(addr(model_ast));
+
+    println "\nTest 4: to_c_identifier for root function and enum prefixes";
+    assert string_equals(str("_1__test"), to_c_identifier(str("1-_test"))), "Expected 1-_test to normalize to _1__test";
 }


### PR DESCRIPTION
I sometimes like to use hyphens in my directory names but encountered compilation issues with the emitted C when doing so. For example, I got:

```
Compiling: ./test-dir/hello.axe
1 | IO
2 | Lex
3 | Parse
4 | Imports
5 | Lowering
6 | PFCCG I
7 | PFCCG II
8 | PFCCG III
9 | PFCCG IV
10| PFCCG V
11| GEN
12| Last compilation pass
./test-dir/hello.c:85:9: error: expected '= constant-expression' or end of enumerator definition
   85 |     test-dir__hello__my_enum_FOO
      |         ^
./test-dir/hello.c:86:3: error: redefinition of 'test' as different kind of symbol
   86 | } test-dir__hello__my_enum;
      |   ^
./test-dir/hello.c:85:5: note: previous definition is here
   85 |     test-dir__hello__my_enum_FOO
      |     ^
./test-dir/hello.c:86:7: error: expected ';' after top level declarator
   86 | } test-dir__hello__my_enum;
      |       ^
      |       ;
./test-dir/hello.c:152:6: error: variable has incomplete type 'void'
  152 | void test-dir__hello__greet(std__string__string name);
      |      ^
./test-dir/hello.c:152:10: error: expected ';' after top level declarator
  152 | void test-dir__hello__greet(std__string__string name);
      |          ^
      |          ;
./test-dir/hello.c:7:6: error: variable has incomplete type 'void'
    7 | void test-dir__hello__greet(std__string__string name) {
      |      ^
./test-dir/hello.c:7:10: error: expected ';' after top level declarator
    7 | void test-dir__hello__greet(std__string__string name) {
      |          ^
      |          ;
7 errors generated.
```
Because the emitted C contains:
```
typedef enum {
    test-dir__hello__my_enum_FOO
} test-dir__hello__my_enum;

...

void test-dir__hello__greet(std__string__string name);
```
To fix this I added `to_c_identifier` to make these prefixes C compatible.